### PR TITLE
feat: introduce TLSConn abstraction and use it consistently

### DIFF
--- a/alpn_test.go
+++ b/alpn_test.go
@@ -36,7 +36,7 @@ func TestNextProtoUpgrade(t *testing.T) {
 	ts.TLS = &tls.Config{
 		NextProtos: []string{"unhandled-proto", "tls-0.9"},
 	}
-	ts.Config.TLSNextProto = map[string]func(*Server, *tls.Conn, Handler){
+	ts.Config.TLSNextProto = map[string]func(*Server, TLSConn, Handler){
 		"tls-0.9": handleTLSProtocol09,
 	}
 	ts.StartTLS()
@@ -105,7 +105,7 @@ func TestNextProtoUpgrade(t *testing.T) {
 
 // handleTLSProtocol09 implements the HTTP/0.9 protocol over TLS, for the
 // TestNextProtoUpgrade test.
-func handleTLSProtocol09(srv *Server, conn *tls.Conn, h Handler) {
+func handleTLSProtocol09(srv *Server, conn TLSConn, h Handler) {
 	br := bufio.NewReader(conn)
 	line, err := br.ReadString('\n')
 	if err != nil {

--- a/tlsconn.go
+++ b/tlsconn.go
@@ -1,0 +1,16 @@
+package http
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// TLSConn is the interface representing a *tls.Conn compatible
+// connection, which could possibly be different from a *tls.Conn
+// as long as it implements the interface. You can use, for
+// example, refraction-networking/utls instead of the stdlib.
+type TLSConn interface {
+	net.Conn
+	ConnectionState() tls.ConnectionState
+	Handshake() error
+}

--- a/transport.go
+++ b/transport.go
@@ -235,7 +235,7 @@ type Transport struct {
 	// must return a RoundTripper that then handles the request.
 	// If TLSNextProto is not nil, HTTP/2 support is not enabled
 	// automatically.
-	TLSNextProto map[string]func(authority string, c *tls.Conn) RoundTripper
+	TLSNextProto map[string]func(authority string, c TLSConn) RoundTripper
 
 	// ProxyConnectHeader optionally specifies headers to send to
 	// proxies during CONNECT requests.
@@ -332,7 +332,7 @@ func (t *Transport) Clone() *Transport {
 		t2.TLSClientConfig = t.TLSClientConfig.Clone()
 	}
 	if !t.tlsNextProtoWasNil {
-		npm := map[string]func(authority string, c *tls.Conn) RoundTripper{}
+		npm := map[string]func(authority string, c TLSConn) RoundTripper{}
 		for k, v := range t.TLSNextProto {
 			npm[k] = v
 		}
@@ -1577,7 +1577,7 @@ func (t *Transport) dialConn(ctx context.Context, cm connectMethod) (pconn *pers
 		if err != nil {
 			return nil, wrapErr(err)
 		}
-		if tc, ok := pconn.conn.(*tls.Conn); ok {
+		if tc, ok := pconn.conn.(TLSConn); ok {
 			// Handshake here, in case DialTLS didn't. TLSNextProto below
 			// depends on it for knowing the connection state.
 			if trace != nil && trace.TLSHandshakeStart != nil {
@@ -1728,7 +1728,7 @@ func (t *Transport) dialConn(ctx context.Context, cm connectMethod) (pconn *pers
 
 	if s := pconn.tlsState; s != nil && s.NegotiatedProtocolIsMutual && s.NegotiatedProtocol != "" {
 		if next, ok := t.TLSNextProto[s.NegotiatedProtocol]; ok {
-			alt := next(cm.targetAddr, pconn.conn.(*tls.Conn))
+			alt := next(cm.targetAddr, pconn.conn.(TLSConn))
 			if e, ok := alt.(erringRoundTripper); ok {
 				// pconn.conn was closed by next (http2configureTransports.upgradeFn).
 				return nil, e.RoundTripErr()

--- a/transport_internal_test.go
+++ b/transport_internal_test.go
@@ -210,7 +210,7 @@ func TestTransportBodyAltRewind(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			if err := sc.(*tls.Conn).Handshake(); err != nil {
+			if err := sc.(TLSConn).Handshake(); err != nil {
 				t.Error(err)
 				return
 			}
@@ -223,8 +223,8 @@ func TestTransportBodyAltRewind(t *testing.T) {
 	roundTripped := false
 	tr := &Transport{
 		DisableKeepAlives: true,
-		TLSNextProto: map[string]func(string, *tls.Conn) RoundTripper{
-			"foo": func(authority string, c *tls.Conn) RoundTripper {
+		TLSNextProto: map[string]func(string, TLSConn) RoundTripper{
+			"foo": func(authority string, c TLSConn) RoundTripper {
 				return roundTripFunc(func(r *Request) (*Response, error) {
 					n, _ := io.Copy(io.Discard, r.Body)
 					if n == 0 {

--- a/transport_test.go
+++ b/transport_test.go
@@ -4205,7 +4205,7 @@ func TestTransportAutomaticHTTP2_DefaultTransport(t *testing.T) {
 
 func TestTransportAutomaticHTTP2_TLSNextProto(t *testing.T) {
 	testTransportAutoHTTP(t, &Transport{
-		TLSNextProto: make(map[string]func(string, *tls.Conn) RoundTripper),
+		TLSNextProto: make(map[string]func(string, TLSConn) RoundTripper),
 	}, false)
 }
 
@@ -4313,7 +4313,7 @@ func TestNoCrashReturningTransportAltConn(t *testing.T) {
 			t.Error(err)
 			return
 		}
-		if err := sc.(*tls.Conn).Handshake(); err != nil {
+		if err := sc.(TLSConn).Handshake(); err != nil {
 			t.Error(err)
 			return
 		}
@@ -4332,8 +4332,8 @@ func TestNoCrashReturningTransportAltConn(t *testing.T) {
 
 	tr := &Transport{
 		DisableKeepAlives: true,
-		TLSNextProto: map[string]func(string, *tls.Conn) RoundTripper{
-			"foo": func(authority string, c *tls.Conn) RoundTripper {
+		TLSNextProto: map[string]func(string, TLSConn) RoundTripper{
+			"foo": func(authority string, c TLSConn) RoundTripper {
 				madeRoundTripper <- true
 				return funcRoundTripper(func() {
 					t.Error("foo RoundTripper should not be called")
@@ -5529,8 +5529,8 @@ func TestTransportClone(t *testing.T) {
 		GetProxyConnectHeader:  func(context.Context, *url.URL, string) (Header, error) { return nil, nil },
 		MaxResponseHeaderBytes: 1,
 		ForceAttemptHTTP2:      true,
-		TLSNextProto: map[string]func(authority string, c *tls.Conn) RoundTripper{
-			"foo": func(authority string, c *tls.Conn) RoundTripper { panic("") },
+		TLSNextProto: map[string]func(authority string, c TLSConn) RoundTripper{
+			"foo": func(authority string, c TLSConn) RoundTripper { panic("") },
 		},
 		ReadBufferSize:  1,
 		WriteBufferSize: 1,


### PR DESCRIPTION
With this abstraction in place, it's quite easy to use
github.com/refraction-networkings/utls with this net/http fork.

```
> git grep 'tls\.Conn'
cgi/child.go:           r.TLS = &tls.ConnectionState{HandshakeComplete: true}
h2_bundle.go:   ConnectionState() tls.ConnectionState
h2_bundle.go:// client. If c has a ConnectionState method like a *tls.Conn, the
h2_bundle.go:           sc.tlsState = new(tls.ConnectionState)
h2_bundle.go:   tlsState         *tls.ConnectionState        // shared by all handlers, like net/http
h2_bundle.go:                   // TODO: add CloseWrite to crypto/tls.Conn first
h2_bundle.go:   var tlsState *tls.ConnectionState // nil if not scheme https
h2_bundle.go:   // If the returned net.Conn has a ConnectionState method like tls.Conn,
h2_bundle.go:   tlsState  *tls.ConnectionState // nil only for specialized impls
httptest/httptest.go:           req.TLS = &tls.ConnectionState{
httptest/httptest_test.go:                              TLS: &tls.ConnectionState{
httptrace/trace.go:     TLSHandshakeDone func(tls.ConnectionState, error)
request.go:     TLS *tls.ConnectionState
response.go:    TLS *tls.ConnectionState
server.go:      tlsState *tls.ConnectionState
server.go:              c.tlsState = new(tls.ConnectionState)
server.go:              req.TLS = &tls.ConnectionState{}
tlsconn.go:// TLSConn is the interface representing a *tls.Conn compatible
tlsconn.go:// connection, which could possibly be different from a *tls.Conn
tlsconn.go:     ConnectionState() tls.ConnectionState
transport.go:                   trace.TLSHandshakeDone(tls.ConnectionState{}, err)
transport.go:                                   trace.TLSHandshakeDone(tls.ConnectionState{}, err)
transport.go:   tlsState  *tls.ConnectionState
transport_test.go:              TLSHandshakeDone: func(s tls.ConnectionState, err error) {
transport_test.go:              TLSHandshakeDone: func(s tls.ConnectionState, err error) {
transport_test.go:                      TLSHandshakeDone: func(cfg tls.ConnectionState, err error) {
```