### PR TITLE
fix(main_test.go): adjust interestingGoroutines filter

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -47,7 +47,7 @@ func interestingGoroutines() (gs []string) {
 			// These only show up with GOTRACEBACK=2; Issue 5005 (comment 28)
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "created by runtime.gc") ||
-			strings.Contains(stack, "net/http_test.interestingGoroutines") ||
+			strings.Contains(stack, "oohttp_test.interestingGoroutines") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") {
 			continue
 		}


### PR DESCRIPTION
Since the paths are different in this fork, we need to adjust such
a filter, otheriwse `go test ./...` reports a (wrong) goroutine leak.