### PR TITLE
feat: add factory for TLS proxying with uTLS (v2)

### DIFF
--- a/tlsconn.go
+++ b/tlsconn.go
@@ -24,7 +24,9 @@ type TLSConn interface {
 }
 
 // TLSClientFactory is the factory used when creating connections
-// using a proxy inside of the HTTP library. By default, this is
-// the tls.Client function. You'll need to override this factory if
+// using a proxy inside of the HTTP library. By default, this will
+// call the tls.Client func. You'll need to override this factory if
 // you want to use refraction-networking/utls for proxied conns.
-var TLSClientFactory = tls.Client
+var TLSClientFactory = func(conn net.Conn, config *tls.Config) TLSConn {
+	return tls.Client(conn, config)
+}


### PR DESCRIPTION
This commit adds an experimental factory for create proxying
TLS connections using uTLS rather than crypto/tls.

A user has requested this functionality.

For now, I'd like to avoid advertising it until I get confirmation
that this interface is okay for the user who requested it.

When it's confirmed it's okay, I'll change the README.

The v1 implementation of this functionality was in commit
d6f7e24250e479a949b8cd230186fe8a4eaed071. Yet, it turns out the
TLSClientFactory ended up having the wrong return type
(`*tls.Conn`). This return type is incorrect; the factory needs
to return `oohttp.TLSConn` instead.