### PR TITLE
feat: add factory for TLS proxying with uTLS (v3)

### DIFF
--- a/tlsconn.go
+++ b/tlsconn.go
@@ -30,3 +30,12 @@ type TLSConn interface {
 var TLSClientFactory = func(conn net.Conn, config *tls.Config) TLSConn {
 	return tls.Client(conn, config)
 }
+
+// tlsClientFactory calls txp.TLSClientFactory if set, otherwise
+// it calls the oohttp.TLSClientFactory global factory.
+func (t *Transport) tlsClientFactory(conn net.Conn, config *tls.Config) TLSConn {
+	if t.TLSClientFactory != nil {
+		return t.TLSClientFactory(conn, config)
+	}
+	return TLSClientFactory(conn, config)
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -5537,8 +5537,9 @@ func TestTransportClone(t *testing.T) {
 		TLSNextProto: map[string]func(authority string, c TLSConn) RoundTripper{
 			"foo": func(authority string, c TLSConn) RoundTripper { panic("") },
 		},
-		ReadBufferSize:  1,
-		WriteBufferSize: 1,
+		ReadBufferSize:   1,
+		WriteBufferSize:  1,
+		TLSClientFactory: TLSClientFactory, // set to the global one
 	}
 	tr2 := tr.Clone()
 	rv := reflect.ValueOf(tr2).Elem()


### PR DESCRIPTION
This commit build upon 475e58062b3ef43e1dacea9d5ecc39bfd4b71353 to
allow users to optionally specify the TLSClientFactory to use on
a per-Transport basis. If the transport TLSClientFactory isn't set,
we'll default to using the global TLSClientFactory.

While working on this diff, I realized that, for the common use
case, a user doesn't need to override DialTLSContext and they can
just set the global or per-transport TLSClientFactory in order
to use their uTLS fingerprint of choice.