### PR TITLE
chore: prepare to merge go1.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ git checkout main
 git remote add golang git@github.com:golang/go.git || git fetch golang
 git branch -D golang-upstream golang-http-upstream merged-main || true
 git fetch golang
-git checkout -b golang-upstream go1.18.2
+git checkout -b golang-upstream go1.18.3
 git subtree split -P src/net/http/ -b golang-http-upstream
 git checkout main
 git checkout -b merged-main


### PR DESCRIPTION
There are no changes in `net/http` since go1.18.2, therefore this PR just updates the README instructions.