### PR TITLE
feat: implement tracing without composition

### DIFF
--- a/httptrace/trace.go
+++ b/httptrace/trace.go
@@ -31,12 +31,24 @@ func ContextClientTrace(ctx context.Context) *ClientTrace {
 // registered with ctx. Any hooks defined in the provided trace will
 // be called first.
 func WithClientTrace(ctx context.Context, trace *ClientTrace) context.Context {
+	return withClientTrace(ctx, trace, true)
+}
+
+// WithClientTraceWithoutComposition is like WithClientTrace except that
+// we're not going to compose with any old trace there may be inside of the
+// chain of contexts. This API seems useful to implement OONI Probe.
+func WithClientTraceWithoutComposition(ctx context.Context, trace *ClientTrace) context.Context {
+	return withClientTrace(ctx, trace, false)
+}
+
+func withClientTrace(ctx context.Context, trace *ClientTrace, compose bool) context.Context {
 	if trace == nil {
 		panic("nil trace")
 	}
-	old := ContextClientTrace(ctx)
-	trace.compose(old)
-
+	if compose {
+		old := ContextClientTrace(ctx)
+		trace.compose(old)
+	}
 	ctx = context.WithValue(ctx, clientEventContextKey{}, trace)
 	return ctx
 }

--- a/httptrace/trace_test.go
+++ b/httptrace/trace_test.go
@@ -87,3 +87,29 @@ func TestCompose(t *testing.T) {
 	}
 
 }
+
+func TestClientTraceWithoutComposition(t *testing.T) {
+	unexpectedFlag := false
+	oldTrace := &ClientTrace{
+		GetConn: func(hostPort string) {
+			unexpectedFlag = true
+		},
+	}
+	ctx := context.Background()
+	ctx = WithClientTraceWithoutComposition(ctx, oldTrace)
+	expectedFlag := false
+	newTrace := &ClientTrace{
+		GetConn: func(hostPort string) {
+			expectedFlag = true
+		},
+	}
+	ctx = WithClientTraceWithoutComposition(ctx, newTrace)
+	maybeCompoundTrace := ContextClientTrace(ctx)
+	maybeCompoundTrace.GetConn("1.2.3.4")
+	if unexpectedFlag {
+		t.Fatal("should be false")
+	}
+	if !expectedFlag {
+		t.Fatal("should be true")
+	}
+}


### PR DESCRIPTION
Tracing with composition is tricky for OONI because we sometimes have
a DoH resolution (so two HTTP round trips) before a real HTTP round trip
when we're using a DoH resolver.

In such a case, tracing with composition complicates attributing the
correct connection to the request that's using it. This happens because
the whole chain of operations is using the same context.Context, so we
end up attaching three traces to the context (one per round trip).

Conversely, if traces do not compose, each round trip gets its own
Trace and we should be able to bind connections and requests.

Because ooni/oohttp is experimental and will always be experimental, I
don't feel bad about adding this API for experimentation and for our
own sake. The original API is still there, so it all feels ~fine.

I will revert this commit if the experiment fails 😬.

Reference issue: https://github.com/ooni/probe/issues/2220