### PR TITLE
Replace http.NoBody with oohttp.NoBody in adapter

### DIFF
--- a/stdlibwrapper.go
+++ b/stdlibwrapper.go
@@ -34,6 +34,13 @@ func (txp *StdlibTransport) RoundTrip(stdReq *http.Request) (*http.Response, err
 		Response:         nil, // cannot assign this field
 		ctx:              stdReq.Context(),
 	}
+
+	// http.NoBody is a global var with oohttp.NoBody being its analogue
+	// this guards against undefined content length in case when stdReq.Body == http.NoBody
+	if req.Body == http.NoBody {
+		req.Body = NoBody
+	}
+
 	resp, err := txp.Transport.RoundTrip(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`http2actualContentLength` in `h2_bundle.go` compares request body against `oohttp.NoBody`, but not against `http.Body`. This results for unknown `reqBodyContentLength` of `-1` for `readTrackingBody` with underlying `http.NoBody` thus leading to a weird frames pattern, i.e. on the screenshot below a DATA frame is sent after a absent-bodied GET-request HEADER frame
![image](https://github.com/ooni/oohttp/assets/30894567/c4d3b22d-9764-45fc-abc4-e361377fd2e7)

Given `stdlibwrapper.go` is an adaptor for standard http requests, I put the replacement there.
