### PR TITLE
feat: minimize diff with upstream

### DIFF
--- a/alpn_test.go
+++ b/alpn_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	. "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
+	httptest "github.com/ooni/oohttp/httptest"
 )
 
 func TestNextProtoUpgrade(t *testing.T) {

--- a/cgi/child.go
+++ b/cgi/child.go
@@ -19,7 +19,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 // Request returns the HTTP request as represented in the current

--- a/cgi/host.go
+++ b/cgi/host.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 	"golang.org/x/net/http/httpguts"
 )
 

--- a/cgi/host_test.go
+++ b/cgi/host_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
+	http "github.com/ooni/oohttp"
+	httptest "github.com/ooni/oohttp/httptest"
 )
 
 func newRequest(httpreq string) *http.Request {

--- a/cgi/integration_test.go
+++ b/cgi/integration_test.go
@@ -9,16 +9,59 @@
 package cgi
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
+	http "github.com/ooni/oohttp"
+	httptest "github.com/ooni/oohttp/httptest"
+	testenv "github.com/ooni/oohttp/internal/testenv"
 )
+
+// This test is a CGI host (testing host.go) that runs its own binary
+// as a child process testing the other half of CGI (child.go).
+func TestHostingOurselves(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	h := &Handler{
+		Path: os.Args[0],
+		Root: "/test.go",
+		Args: []string{"-test.run=TestBeChildCGIProcess"},
+	}
+	expectedMap := map[string]string{
+		"test":                  "Hello CGI-in-CGI",
+		"param-a":               "b",
+		"param-foo":             "bar",
+		"env-GATEWAY_INTERFACE": "CGI/1.1",
+		"env-HTTP_HOST":         "example.com",
+		"env-PATH_INFO":         "",
+		"env-QUERY_STRING":      "foo=bar&a=b",
+		"env-REMOTE_ADDR":       "1.2.3.4",
+		"env-REMOTE_HOST":       "1.2.3.4",
+		"env-REMOTE_PORT":       "1234",
+		"env-REQUEST_METHOD":    "GET",
+		"env-REQUEST_URI":       "/test.go?foo=bar&a=b",
+		"env-SCRIPT_FILENAME":   os.Args[0],
+		"env-SCRIPT_NAME":       "/test.go",
+		"env-SERVER_NAME":       "example.com",
+		"env-SERVER_PORT":       "80",
+		"env-SERVER_SOFTWARE":   "go",
+	}
+	replay := runCgiTest(t, h, "GET /test.go?foo=bar&a=b HTTP/1.0\nHost: example.com\n\n", expectedMap)
+
+	if expected, got := "text/plain; charset=utf-8", replay.Header().Get("Content-Type"); got != expected {
+		t.Errorf("got a Content-Type of %q; expected %q", got, expected)
+	}
+	if expected, got := "X-Test-Value", replay.Header().Get("X-Test-Header"); got != expected {
+		t.Errorf("got a X-Test-Header of %q; expected %q", got, expected)
+	}
+}
 
 type customWriterRecorder struct {
 	w io.Writer
@@ -46,6 +89,109 @@ func (w *limitWriter) Write(p []byte) (n int, err error) {
 		err = errors.New("past write limit")
 	}
 	return
+}
+
+// If there's an error copying the child's output to the parent, test
+// that we kill the child.
+func TestKillChildAfterCopyError(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	h := &Handler{
+		Path: os.Args[0],
+		Root: "/test.go",
+		Args: []string{"-test.run=TestBeChildCGIProcess"},
+	}
+	req, _ := http.NewRequest("GET", "http://example.com/test.cgi?write-forever=1", nil)
+	rec := httptest.NewRecorder()
+	var out bytes.Buffer
+	const writeLen = 50 << 10
+	rw := &customWriterRecorder{&limitWriter{&out, writeLen}, rec}
+
+	h.ServeHTTP(rw, req)
+	if out.Len() != writeLen || out.Bytes()[0] != 'a' {
+		t.Errorf("unexpected output: %q", out.Bytes())
+	}
+}
+
+// Test that a child handler writing only headers works.
+// golang.org/issue/7196
+func TestChildOnlyHeaders(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	h := &Handler{
+		Path: os.Args[0],
+		Root: "/test.go",
+		Args: []string{"-test.run=TestBeChildCGIProcess"},
+	}
+	expectedMap := map[string]string{
+		"_body": "",
+	}
+	replay := runCgiTest(t, h, "GET /test.go?no-body=1 HTTP/1.0\nHost: example.com\n\n", expectedMap)
+	if expected, got := "X-Test-Value", replay.Header().Get("X-Test-Header"); got != expected {
+		t.Errorf("got a X-Test-Header of %q; expected %q", got, expected)
+	}
+}
+
+// Test that a child handler does not receive a nil Request Body.
+// golang.org/issue/39190
+func TestNilRequestBody(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	h := &Handler{
+		Path: os.Args[0],
+		Root: "/test.go",
+		Args: []string{"-test.run=TestBeChildCGIProcess"},
+	}
+	expectedMap := map[string]string{
+		"nil-request-body": "false",
+	}
+	_ = runCgiTest(t, h, "POST /test.go?nil-request-body=1 HTTP/1.0\nHost: example.com\n\n", expectedMap)
+	_ = runCgiTest(t, h, "POST /test.go?nil-request-body=1 HTTP/1.0\nHost: example.com\nContent-Length: 0\n\n", expectedMap)
+}
+
+func TestChildContentType(t *testing.T) {
+	testenv.MustHaveExec(t)
+
+	h := &Handler{
+		Path: os.Args[0],
+		Root: "/test.go",
+		Args: []string{"-test.run=TestBeChildCGIProcess"},
+	}
+	var tests = []struct {
+		name   string
+		body   string
+		wantCT string
+	}{
+		{
+			name:   "no body",
+			wantCT: "text/plain; charset=utf-8",
+		},
+		{
+			name:   "html",
+			body:   "<html><head><title>test page</title></head><body>This is a body</body></html>",
+			wantCT: "text/html; charset=utf-8",
+		},
+		{
+			name:   "text",
+			body:   strings.Repeat("gopher", 86),
+			wantCT: "text/plain; charset=utf-8",
+		},
+		{
+			name:   "jpg",
+			body:   "\xFF\xD8\xFF" + strings.Repeat("B", 1024),
+			wantCT: "image/jpeg",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedMap := map[string]string{"_body": tt.body}
+			req := fmt.Sprintf("GET /test.go?exact-body=%s HTTP/1.0\nHost: example.com\n\n", url.QueryEscape(tt.body))
+			replay := runCgiTest(t, h, req, expectedMap)
+			if got := replay.Header().Get("Content-Type"); got != tt.wantCT {
+				t.Errorf("got a Content-Type of %q; expected it to start with %q", got, tt.wantCT)
+			}
+		})
+	}
 }
 
 // golang.org/issue/7198

--- a/client_test.go
+++ b/client_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/url"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,8 +27,9 @@ import (
 	"time"
 
 	. "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/cookiejar"
-	"github.com/ooni/oohttp/httptest"
+	cookiejar "github.com/ooni/oohttp/cookiejar"
+	httptest "github.com/ooni/oohttp/httptest"
+	testenv "github.com/ooni/oohttp/internal/testenv"
 )
 
 var robotsTxtHandler = HandlerFunc(func(w ResponseWriter, r *Request) {
@@ -1237,6 +1239,9 @@ func testClientTimeout(t *testing.T, mode testMode) {
 				t.Logf("timeout before response received")
 				continue
 			}
+			if runtime.GOOS == "windows" && strings.HasPrefix(runtime.GOARCH, "arm") {
+				testenv.SkipFlaky(t, 43120)
+			}
 			t.Fatal(err)
 		}
 
@@ -1260,6 +1265,9 @@ func testClientTimeout(t *testing.T, mode testMode) {
 			t.Errorf("net.Error.Timeout = false; want true")
 		}
 		if got := ne.Error(); !strings.Contains(got, "(Client.Timeout") {
+			if runtime.GOOS == "windows" && strings.HasPrefix(runtime.GOARCH, "arm") {
+				testenv.SkipFlaky(t, 43120)
+			}
 			t.Errorf("error string = %q; missing timeout substring", got)
 		}
 
@@ -1300,6 +1308,9 @@ func testClientTimeout_Headers(t *testing.T, mode testMode) {
 		t.Error("net.Error.Timeout = false; want true")
 	}
 	if got := ne.Error(); !strings.Contains(got, "Client.Timeout exceeded") {
+		if runtime.GOOS == "windows" && strings.HasPrefix(runtime.GOARCH, "arm") {
+			testenv.SkipFlaky(t, 43120)
+		}
 		t.Errorf("error string = %q; missing timeout substring", got)
 	}
 }

--- a/clientserver_test.go
+++ b/clientserver_test.go
@@ -31,9 +31,9 @@ import (
 	"time"
 
 	. "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/httputil"
+	httptest "github.com/ooni/oohttp/httptest"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	httputil "github.com/ooni/oohttp/httputil"
 )
 
 type testMode string

--- a/cookie.go
+++ b/cookie.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ooni/oohttp/internal/ascii"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 )
 
 // A Cookie represents an HTTP cookie as sent in the Set-Cookie header of an

--- a/cookiejar/example_test.go
+++ b/cookiejar/example_test.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"net/url"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/cookiejar"
-	"github.com/ooni/oohttp/httptest"
+	http "github.com/ooni/oohttp"
+	cookiejar "github.com/ooni/oohttp/cookiejar"
+	httptest "github.com/ooni/oohttp/httptest"
 )
 
 func ExampleNew() {

--- a/cookiejar/jar.go
+++ b/cookiejar/jar.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/internal/ascii"
+	http "github.com/ooni/oohttp"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 )
 
 // PublicSuffixList provides the public suffix of a domain. For example:

--- a/cookiejar/jar_test.go
+++ b/cookiejar/jar_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 // tNow is the synthetic current time used as now during testing.

--- a/cookiejar/punycode.go
+++ b/cookiejar/punycode.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/ooni/oohttp/internal/ascii"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 )
 
 // These parameter values are specified in section 5.

--- a/example_filesystem_test.go
+++ b/example_filesystem_test.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 // containsDotFile reports whether name contains a path element starting with a period.

--- a/example_handle_test.go
+++ b/example_handle_test.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 type countHandler struct {

--- a/example_test.go
+++ b/example_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 func ExampleHijacker() {

--- a/fcgi/child.go
+++ b/fcgi/child.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/cgi"
+	http "github.com/ooni/oohttp"
+	cgi "github.com/ooni/oohttp/cgi"
 )
 
 // request holds the state for an in-progress request. As soon as it's complete,

--- a/fcgi/fcgi_test.go
+++ b/fcgi/fcgi_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 var sizeTests = []struct {

--- a/fs.go
+++ b/fs.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ooni/oohttp/internal/safefilepath"
+	safefilepath "github.com/ooni/oohttp/internal/safefilepath"
 )
 
 // A Dir implements FileSystem using the native file system restricted to a

--- a/fs_test.go
+++ b/fs_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	. "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
+	httptest "github.com/ooni/oohttp/httptest"
 )
 
 const (

--- a/h2_bundle.go
+++ b/h2_bundle.go
@@ -47,7 +47,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ooni/oohttp/httptrace"
+	httptrace "github.com/ooni/oohttp/httptrace"
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http2/hpack"
 	"golang.org/x/net/idna"

--- a/header.go
+++ b/header.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/internal/ascii"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 	"golang.org/x/net/http/httpguts"
 )
 

--- a/http_test.go
+++ b/http_test.go
@@ -7,9 +7,17 @@
 package http
 
 import (
+	"bytes"
+	"io/fs"
 	"net/url"
+	"os"
+	"os/exec"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
+
+	testenv "github.com/ooni/oohttp/internal/testenv"
 )
 
 func TestForeachHeaderElement(t *testing.T) {
@@ -38,6 +46,68 @@ func TestForeachHeaderElement(t *testing.T) {
 		if !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("foreachHeaderElement(%q) = %q; want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+// Test that cmd/go doesn't link in the HTTP server.
+//
+// This catches accidental dependencies between the HTTP transport and
+// server code.
+func TestCmdGoNoHTTPServer(t *testing.T) {
+	t.Skip("test disabled in the github.com/ooni/oohttp fork")
+	t.Parallel()
+	goBin := testenv.GoToolPath(t)
+	out, err := exec.Command(goBin, "tool", "nm", goBin).CombinedOutput()
+	if err != nil {
+		t.Fatalf("go tool nm: %v: %s", err, out)
+	}
+	wantSym := map[string]bool{
+		// Verify these exist: (sanity checking this test)
+		"net/http.(*Client).do":           true,
+		"net/http.(*Transport).RoundTrip": true,
+
+		// Verify these don't exist:
+		"net/http.http2Server":           false,
+		"net/http.(*Server).Serve":       false,
+		"net/http.(*ServeMux).ServeHTTP": false,
+		"net/http.DefaultServeMux":       false,
+	}
+	for sym, want := range wantSym {
+		got := bytes.Contains(out, []byte(sym))
+		if !want && got {
+			t.Errorf("cmd/go unexpectedly links in HTTP server code; found symbol %q in cmd/go", sym)
+		}
+		if want && !got {
+			t.Errorf("expected to find symbol %q in cmd/go; not found", sym)
+		}
+	}
+}
+
+// Tests that the nethttpomithttp2 build tag doesn't rot too much,
+// even if there's not a regular builder on it.
+func TestOmitHTTP2(t *testing.T) {
+	t.Skip("test disabled in the github.com/ooni/oohttp fork")
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	t.Parallel()
+	goTool := testenv.GoToolPath(t)
+	out, err := exec.Command(goTool, "test", "-short", "-tags=nethttpomithttp2", "net/http").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go test -short failed: %v, %s", err, out)
+	}
+}
+
+// Tests that the nethttpomithttp2 build tag at least type checks
+// in short mode.
+// The TestOmitHTTP2 test above actually runs tests (in long mode).
+func TestOmitHTTP2Vet(t *testing.T) {
+	t.Skip("test disabled in the github.com/ooni/oohttp fork")
+	t.Parallel()
+	goTool := testenv.GoToolPath(t)
+	out, err := exec.Command(goTool, "vet", "-tags=nethttpomithttp2", "net/http").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go vet failed: %v, %s", err, out)
 	}
 }
 
@@ -80,4 +150,46 @@ var forbiddenStringsFunctions = map[string]bool{
 	// Functions that use Unicode-aware spaces.
 	"Fields":    true,
 	"TrimSpace": true,
+}
+
+// TestNoUnicodeStrings checks that nothing in net/http uses the Unicode-aware
+// strings and bytes package functions. HTTP is mostly ASCII based, and doing
+// Unicode-aware case folding or space stripping can introduce vulnerabilities.
+func TestNoUnicodeStrings(t *testing.T) {
+	if !testenv.HasSrc() {
+		t.Skip("source code not available")
+	}
+
+	re := regexp.MustCompile(`(strings|bytes).([A-Za-z]+)`)
+	if err := fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if path == "internal/ascii" {
+			return fs.SkipDir
+		}
+		if !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") ||
+			path == "h2_bundle.go" || d.IsDir() {
+			return nil
+		}
+
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for lineNum, line := range strings.Split(string(contents), "\n") {
+			for _, match := range re.FindAllStringSubmatch(line, -1) {
+				if !forbiddenStringsFunctions[match[2]] {
+					continue
+				}
+				t.Errorf("disallowed call to %s at %s:%d", match[0], path, lineNum+1)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/httptest/example_test.go
+++ b/httptest/example_test.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"log"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
+	http "github.com/ooni/oohttp"
+	httptest "github.com/ooni/oohttp/httptest"
 )
 
 func ExampleResponseRecorder() {

--- a/httptest/httptest.go
+++ b/httptest/httptest.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 // NewRequest returns a new incoming server Request, suitable

--- a/httptest/httptest_test.go
+++ b/httptest/httptest_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 func TestNewRequest(t *testing.T) {

--- a/httptest/recorder.go
+++ b/httptest/recorder.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 	"golang.org/x/net/http/httpguts"
 )
 

--- a/httptest/recorder_test.go
+++ b/httptest/recorder_test.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 func TestRecorder(t *testing.T) {

--- a/httptest/server.go
+++ b/httptest/server.go
@@ -18,8 +18,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/internal/testcert"
+	http "github.com/ooni/oohttp"
+	testcert "github.com/ooni/oohttp/internal/testcert"
 )
 
 // A Server is an HTTP server listening on a system-chosen port on the

--- a/httptrace/example_test.go
+++ b/httptrace/example_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptrace"
+	http "github.com/ooni/oohttp"
+	httptrace "github.com/ooni/oohttp/httptrace"
 )
 
 func Example() {

--- a/httputil/dump.go
+++ b/httputil/dump.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 // drainBody reads all of b to memory and then returns two equivalent

--- a/httputil/dump_test.go
+++ b/httputil/dump_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 type eofReader struct{}

--- a/httputil/example_test.go
+++ b/httputil/example_test.go
@@ -11,9 +11,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
-	"github.com/ooni/oohttp/httputil"
+	http "github.com/ooni/oohttp"
+	httptest "github.com/ooni/oohttp/httptest"
+	httputil "github.com/ooni/oohttp/httputil"
 )
 
 func ExampleDumpRequest() {

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -9,7 +9,7 @@ package httputil
 import (
 	"io"
 
-	"github.com/ooni/oohttp/internal"
+	internal "github.com/ooni/oohttp/internal"
 )
 
 // NewChunkedReader returns a new chunkedReader that translates the data read from r

--- a/httputil/persist.go
+++ b/httputil/persist.go
@@ -12,7 +12,7 @@ import (
 	"net/textproto"
 	"sync"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 var (

--- a/httputil/reverseproxy.go
+++ b/httputil/reverseproxy.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	http "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/internal/ascii"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 	"golang.org/x/net/http/httpguts"
 )
 

--- a/httputil/reverseproxy_test.go
+++ b/httputil/reverseproxy_test.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	http "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/internal/ascii"
+	httptest "github.com/ooni/oohttp/httptest"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 )
 
 const fakeHopHeader = "X-Fake-Hop-Header-For-Test"

--- a/internal/fakerace/fakerace.go
+++ b/internal/fakerace/fakerace.go
@@ -1,0 +1,4 @@
+// Package fakerace fakes out the internal/race package.
+package fakerace
+
+const Enabled = false

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,30 @@
+// Package testenv emulates some testenv properties to reduce
+// the amount of deleted line with respect to upstream.
+package testenv
+
+import "testing"
+
+// MustHaveExec always skips the current test.
+func MustHaveExec(t testing.TB) {
+	t.Skip("testenv.MustHaveExec is not enabled in this fork")
+}
+
+// SkipFlay skips a flaky test.
+func SkipFlaky(t testing.TB, issue int) {
+	t.Skip("testenv.SkipFlaky: skipping flaky test", issue)
+}
+
+// HasSrc always returns false.
+func HasSrc() bool {
+	return false
+}
+
+// GoToolPath returns the Go tool path.
+func GoToolPath(t testing.TB) string {
+	return "go"
+}
+
+// Builder always returns the empty string.
+func Builder() string {
+	return ""
+}

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 var quietLog = log.New(io.Discard, "", 0)

--- a/request.go
+++ b/request.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/internal/ascii"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/idna"
 )

--- a/transfer.go
+++ b/transfer.go
@@ -18,9 +18,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/internal"
-	"github.com/ooni/oohttp/internal/ascii"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	internal "github.com/ooni/oohttp/internal"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 	"golang.org/x/net/http/httpguts"
 )
 

--- a/transport.go
+++ b/transport.go
@@ -28,8 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/internal/ascii"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	ascii "github.com/ooni/oohttp/internal/ascii"
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/net/http/httpproxy"
 )

--- a/transport_internal_test.go
+++ b/transport_internal_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ooni/oohttp/internal/testcert"
+	testcert "github.com/ooni/oohttp/internal/testcert"
 )
 
 // Issue 15446: incorrect wrapping of errors when server closes an idle connection.

--- a/transport_test.go
+++ b/transport_test.go
@@ -39,10 +39,10 @@ import (
 	"time"
 
 	. "github.com/ooni/oohttp"
-	"github.com/ooni/oohttp/httptest"
-	"github.com/ooni/oohttp/httptrace"
-	"github.com/ooni/oohttp/httputil"
-	"github.com/ooni/oohttp/internal/testcert"
+	httptest "github.com/ooni/oohttp/httptest"
+	httptrace "github.com/ooni/oohttp/httptrace"
+	httputil "github.com/ooni/oohttp/httputil"
+	testcert "github.com/ooni/oohttp/internal/testcert"
 	"golang.org/x/net/http/httpguts"
 )
 

--- a/triv.go
+++ b/triv.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/ooni/oohttp"
+	http "github.com/ooni/oohttp"
 )
 
 // hello world, the web server


### PR DESCRIPTION
This diff attempts to minimize the diff with upstream. We can definitely further minimize it, but this is a first attempt at making sure we stay as close as possible to it. The general idea is to make merging simpler and more obvious.

For documentation reasons, here's the diff between us and upstream after this PR:  [DIFF.txt](https://github.com/ooni/oohttp/files/14760319/DIFF.txt)
