### PR TITLE
chore: upgrade examples to use oohttp v0.8.1

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/dreadl0ck/tlsx v1.0.1-google-gopacket
 	github.com/google/go-cmp v0.6.0
 	github.com/google/martian/v3 v3.3.3
-	github.com/ooni/oohttp v0.8.0
+	github.com/ooni/oohttp v0.8.1
 	github.com/refraction-networking/utls v1.6.7
 	golang.org/x/net v0.31.0
 )

--- a/example/go.sum
+++ b/example/go.sum
@@ -22,8 +22,8 @@ github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
-github.com/ooni/oohttp v0.8.0 h1:D256SKWc8FFN5WvNpG0ImomtXP3deAiRmxoN2GfKUeQ=
-github.com/ooni/oohttp v0.8.0/go.mod h1:6KnSv/hwqZFegFugPEHUGFghmby/9LavhA3BtCE+RQ4=
+github.com/ooni/oohttp v0.8.1 h1:WVTgmweiR9398vZcRchwnQqqPo//1pIl2xnlvdvPV9w=
+github.com/ooni/oohttp v0.8.1/go.mod h1:6KnSv/hwqZFegFugPEHUGFghmby/9LavhA3BtCE+RQ4=
 github.com/refraction-networking/utls v1.6.7 h1:zVJ7sP1dJx/WtVuITug3qYUq034cDq9B2MR1K67ULZM=
 github.com/refraction-networking/utls v1.6.7/go.mod h1:BC3O4vQzye5hqpmDTWUqi4P5DDhzJfkV1tdqtawQIH0=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=


### PR DESCRIPTION
This diff updates the examples to oohttp v0.8.1